### PR TITLE
Fullscreen

### DIFF
--- a/LARSAdController.podspec
+++ b/LARSAdController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'LARSAdController'
-  s.version = '3.0.7'
+  s.version = '3.0.8'
   s.summary = 'Lightweight ad mediation for iOS to properly manage multiple ad networks dynamically including iAd and Google ads.'
   s.description = 'A lightweight singleton ad mediation platform for iOS. Ads are managed in a way that most closely adheres to best practices for ad networks using a single instance for each ad network in order to provide the best publishing platform for advertisers to maximize ad inventory based on your particular needs. Currently there are two adapters available (iAd and Google Ads). The adapters can be extended to any ad framework wanted.'
   s.homepage = 'http://larsacus.github.com/LARSAdController/'

--- a/LARSAdController.podspec
+++ b/LARSAdController.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   end
   
   s.subspec 'GoogleAds' do |g|
-      g.source_files = 'Source/TOLAdAdapterGoogleAds.{h,m}'
+      g.source_files = 'Source/TOLAdAdapterGoogleAds.{h,m}','Source/TOLAdAdapterGoogleAdsInterstitial.{h,m}'
       g.dependency 'Google-Mobile-Ads-SDK'
       g.dependency 'LARSAdController/Core'
       g.weak_frameworks = 'AdSupport'

--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ To make your life even _easier_, all you need to do is have each of your view co
 
 
 ###Full-Screen Ads
-To call a full-screen ad on supported adapters simply call
+To call a full-screen ad on supported adapters simply call:
 
-``` objectice-c
+``` objective-c
 [[LARSAdController sharedManager] loadInterstitial];
 ```
-to start loading the full-screen ad. Then call
+to start loading the full-screen ad. Then call:
 
 ``` objective-c
 [[LARSAdController sharedManager] displayInterstitial];

--- a/README.md
+++ b/README.md
@@ -137,7 +137,13 @@ to start loading the full-screen ad. Then call:
 [[LARSAdController sharedManager] displayInterstitial];
 ```
 
-to display it. Every call to display must be matched with a load call beforehand. If the ad has not fully loaded during the time-frame nothing will happen.
+to display it. Every call to display must be matched with a load call beforehand. If the ad has not fully loaded during the time-frame nothing will happen. Note GoogleAds use a different publisher id for interstitial ads, therefore another adapter must be registered with the ad manager:
+``` objective-c
+#import <LARSAdController/TOLAdAdapterGoogleAdsInterstitial.h>
+/* ... */
+   [[LARSAdController sharedManager] registerAdClass:[TOLAdApaterGoogleAdsInterstitial class]
+                                     withPublisherId: interstitialPublisherId];
+```
 
 ####Conditionally Displaying Ads
 If you'd only like the ads to be displayed under certain conditions (like when a user has purchased a certain in-app upgrade), then simply override `-shouldDisplayAds` in your `TOLAdViewController` subclass. Ads will not be loaded on `viewWillAppear:` if `shouldDisplayAds` returns `NO`:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ To make your life even _easier_, all you need to do is have each of your view co
 @end
 ```
 
+
+###Full-Screen Ads
+To call a full-screen ad on supported adapters simply call
+
+``` objectice-c
+[[LARSAdController sharedManager] loadInterstitial];
+```
+to start loading the full-screen ad. Then call
+
+``` objective-c
+[[LARSAdController sharedManager] displayInterstitial];
+```
+
+to display it. Every call to display must be matched with a load call beforehand. If the ad has not fully loaded during the time-frame nothing will happen.
+
 ####Conditionally Displaying Ads
 If you'd only like the ads to be displayed under certain conditions (like when a user has purchased a certain in-app upgrade), then simply override `-shouldDisplayAds` in your `TOLAdViewController` subclass. Ads will not be loaded on `viewWillAppear:` if `shouldDisplayAds` returns `NO`:
 

--- a/Source/LARSAdController.h
+++ b/Source/LARSAdController.h
@@ -50,6 +50,9 @@ typedef NS_ENUM(NSInteger, LARSAdControllerPinLocation){
     LARSAdControllerPinLocationTop
 };
 
+
+
+
 @protocol LARSBannerVisibilityDelegate;
 
 @interface LARSAdContainer : UIView
@@ -91,6 +94,13 @@ typedef NS_ENUM(NSInteger, LARSAdControllerPinLocation){
     requests will be included in this dictionary.
  */
 @property (strong, nonatomic, readonly) NSMutableDictionary *adapterInstances;
+
+/** The instances for each INTERSTITIAL ad adapter that are currently instantiated. Not all registered ad adapters
+ will be instantiated at any given time. Only the active ad adapters currently waiting on ad network
+ requests will be included in this dictionary.
+ */
+@property (strong,nonatomic,readonly) NSMutableDictionary *adapterInterstitialInstances;
+
 
 /** The presentation type for the ad banner to use when it presents and hides itself. You can think 
     of this as the location that ad banner will be at before it animates on screen.
@@ -169,6 +179,15 @@ typedef NS_ENUM(NSInteger, LARSAdControllerPinLocation){
 /** Resume again after suspend. Will make banners re-appear (move in screen).
  */
 - (void)resume;
+
+
+/** prepare loading interstitial (full-screen) ad
+ */
+-(void) loadInterstitial;
+
+/** display interstitial (full-screen) ad
+ */
+-(void) displayInterstitial;
 
 @end
 

--- a/Source/LARSAdController.m
+++ b/Source/LARSAdController.m
@@ -560,6 +560,13 @@ CGFloat const kLARSAdContainerHeightPod = 50.0f;
 
 - (BOOL)startAdNetworkAdapterClass:(Class)klass withType:(LARSAdControllerAdapterInstanceTYpe)type {
     
+    if(
+      ( (![klass allowsBanner])  && type == LARSAdControllerAdapterInstanceBanner) ||
+      ( (![klass allowsInterstitial]) && type == LARSAdControllerAdapterInstanceInterstitial)
+       ) {
+        return NO;
+    }
+    
     NSObject <TOLAdAdapter> *adapter = nil;
     if( type == LARSAdControllerAdapterInstanceBanner ) {
         adapter = [self.adapterInstances objectForKey:NSStringFromClass(klass)];

--- a/Source/TOLAdAdapter.h
+++ b/Source/TOLAdAdapter.h
@@ -38,9 +38,7 @@
 @protocol TOLAdAdapter <NSObject>
 
 @required
-/** The actual banner view that will be displaying ads for the ad vendor.
- */
-@property (strong, nonatomic) UIView *bannerView;
+
 
 /** A boolean flag that is set whenever an ad for this adapter is visible on screen. 
     The contents of this is managed by the ad controller.
@@ -51,8 +49,20 @@
  */
 @property (weak, nonatomic) id <LARSAdControllerDelegate> adManager;
 
-/** Lays out the banner view for a given orientation. Does not necessarily need to set the frame's 
-    origin correctly, just the banner's size. The banner's position is set by the ad controller.
+
++(BOOL) allowsBanner;
+
++(BOOL) allowsInterstitial;
+
+@optional
+
+
+/** The actual banner view that will be displaying ads for the ad vendor.
+ */
+@property (strong, nonatomic) UIView *bannerView;
+
+/** Lays out the banner view for a given orientation. Does not necessarily need to set the frame's
+ origin correctly, just the banner's size. The banner's position is set by the ad controller.
  
  @param interfaceOrientation The interface orientation to layout the banner view for
  @param containerView The UIView that the bannerView will live inside
@@ -61,7 +71,6 @@
 - (void)layoutBannerForInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
                                forContainer:(UIView *)containerView;
 
-@optional
 
 /** Starts ad requests. This method is optional because not all ad networks have a the concept of 
     "start" or "pause". If they are allocated and alive, they are service ads indefinitely until deallocated.
@@ -96,6 +105,11 @@
     publisher id (iAds, for example).
  */
 @property (copy, nonatomic) NSString *publisherId;
+
+/** Interstitial ad publisher Id
+    set a different publisher Id for interstitial Ads, if not set will fallback to default publisherId, if needed
+ */
+@property (copy,nonatomic) NSString * interstitialPublisherId;
 
 /** The parent view controller that is managing the view that the ad is currently living in.
  */

--- a/Source/TOLAdAdapter.h
+++ b/Source/TOLAdAdapter.h
@@ -106,4 +106,13 @@
  */
 @property (nonatomic, readonly) BOOL adLoaded;
 
+
+/** starts loading interstitial (full-screen) ad
+ */
+-(void) loadInterstitial;
+
+/** displays interstitial (full-screen) ad if available
+ */
+-(void) displayInterstitial;
+
 @end

--- a/Source/TOLAdAdapterGoogleAds.h
+++ b/Source/TOLAdAdapterGoogleAds.h
@@ -28,15 +28,15 @@
 #import "TOLAdAdapter.h"
 #import "GADBannerViewDelegate.h"
 #import "GADBannerView.h"
-#import "GADInterstitial.h"
 
-@interface TOLAdAdapterGoogleAds : NSObject <TOLAdAdapter, GADBannerViewDelegate,GADInterstitialDelegate>
+
+@interface TOLAdAdapterGoogleAds : NSObject <TOLAdAdapter, GADBannerViewDelegate>
 
 @property (weak, nonatomic) id<LARSAdControllerDelegate> adManager;
 @property (nonatomic) BOOL adVisible;
 @property (strong, nonatomic) GADBannerView *bannerView;
 @property (copy, nonatomic) NSString *publisherId;
 @property (weak, nonatomic) UIViewController *parentViewController;
-@property (strong,nonatomic) GADInterstitial * interstitial;
+
 
 @end

--- a/Source/TOLAdAdapterGoogleAds.h
+++ b/Source/TOLAdAdapterGoogleAds.h
@@ -28,13 +28,15 @@
 #import "TOLAdAdapter.h"
 #import "GADBannerViewDelegate.h"
 #import "GADBannerView.h"
+#import "GADInterstitial.h"
 
-@interface TOLAdAdapterGoogleAds : NSObject <TOLAdAdapter, GADBannerViewDelegate>
+@interface TOLAdAdapterGoogleAds : NSObject <TOLAdAdapter, GADBannerViewDelegate,GADInterstitialDelegate>
 
 @property (weak, nonatomic) id<LARSAdControllerDelegate> adManager;
 @property (nonatomic) BOOL adVisible;
 @property (strong, nonatomic) GADBannerView *bannerView;
 @property (copy, nonatomic) NSString *publisherId;
 @property (weak, nonatomic) UIViewController *parentViewController;
+@property (strong,nonatomic) GADInterstitial * interstitial;
 
 @end

--- a/Source/TOLAdAdapterGoogleAds.m
+++ b/Source/TOLAdAdapterGoogleAds.m
@@ -28,6 +28,15 @@
 @implementation TOLAdAdapterGoogleAds
 
 #pragma mark - Required Adapted Implementation
+
++ (BOOL)allowsBanner {
+    return YES;
+}
+
++ (BOOL)allowsInterstitial {
+    return NO;
+}
+
 - (GADBannerView *)bannerView {
     if (_bannerView == nil && _publisherId) {
         
@@ -63,6 +72,8 @@
 - (void)dealloc {
     _bannerView.delegate = nil;
     _bannerView = nil;
+    
+
     
     self.adManager = nil;
     self.publisherId = nil;
@@ -129,42 +140,6 @@
     TOLLog(@"Google ad did fail to receive ad");
 }
 
-
-#pragma mark - Interstitial protocol implementation
-- (void)loadInterstitial {
-    self.interstitial = [[GADInterstitial alloc] init];
-    self.interstitial.adUnitID = self.publisherId;
-    self.interstitial.delegate = self;
-    
-    GADRequest *request = [GADRequest request];
-    // Requests test ads on simulators.
-    request.testDevices = @[ GAD_SIMULATOR_ID ];
-    [self.interstitial loadRequest:request];
-}
-
-- (void)displayInterstitial {
-    if( _parentViewController != nil ) {
-        if( self.interstitial != nil ) {
-            if( self.interstitial.isReady ) {
-                [self.interstitial presentFromRootViewController:_parentViewController];
-                self.interstitial = nil; /* release it */
-            }
-        } else {
-            TOLWLog(@"Attempting to display unallocated interstitial");
-        }
-    } else {
-        TOLWLog(@"cannot display interstitial, controller does not have parent view");
-    }
-}
-
-#pragma mark - GADInterstitial delegate methos
-- (void)interstitialDidReceiveAd:(GADInterstitial *)ad {
-    TOLLog(@"got interstitial ad");
-}
-
-- (void)interstitial:(GADInterstitial *)ad didFailToReceiveAdWithError:(GADRequestError *)error {
-    TOLLog(@"failed to load interstitial ad");
-}
 
 /** Unused Google Ad Delegate Methods
 */

--- a/Source/TOLAdAdapterGoogleAds.m
+++ b/Source/TOLAdAdapterGoogleAds.m
@@ -129,6 +129,43 @@
     TOLLog(@"Google ad did fail to receive ad");
 }
 
+
+#pragma mark - Interstitial protocol implementation
+- (void)loadInterstitial {
+    self.interstitial = [[GADInterstitial alloc] init];
+    self.interstitial.adUnitID = self.publisherId;
+    self.interstitial.delegate = self;
+    
+    GADRequest *request = [GADRequest request];
+    // Requests test ads on simulators.
+    request.testDevices = @[ GAD_SIMULATOR_ID ];
+    [self.interstitial loadRequest:request];
+}
+
+- (void)displayInterstitial {
+    if( _parentViewController != nil ) {
+        if( self.interstitial != nil ) {
+            if( self.interstitial.isReady ) {
+                [self.interstitial presentFromRootViewController:_parentViewController];
+                self.interstitial = nil; /* release it */
+            }
+        } else {
+            TOLWLog(@"Attempting to display unallocated interstitial");
+        }
+    } else {
+        TOLWLog(@"cannot display interstitial, controller does not have parent view");
+    }
+}
+
+#pragma mark - GADInterstitial delegate methos
+- (void)interstitialDidReceiveAd:(GADInterstitial *)ad {
+    TOLLog(@"got interstitial ad");
+}
+
+- (void)interstitial:(GADInterstitial *)ad didFailToReceiveAdWithError:(GADRequestError *)error {
+    TOLLog(@"failed to load interstitial ad");
+}
+
 /** Unused Google Ad Delegate Methods
 */
 //- (void)adViewWillPresentScreen:(GADBannerView *)bannerView{

--- a/Source/TOLAdAdapterGoogleAdsInterstitial.h
+++ b/Source/TOLAdAdapterGoogleAdsInterstitial.h
@@ -1,0 +1,24 @@
+//
+//  TOLAdApaterGoogleAdsInterstitial.h
+//  Pods
+//
+//  Created by Bruno Dal Bó Silva on 12/2/14.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#import "GADInterstitial.h"
+#import "TOLAdAdapter.h"
+#import "LARSAdController.h"
+
+@interface TOLAdApaterGoogleAdsInterstitial : NSObject <GADInterstitialDelegate,TOLAdAdapter>
+
+@property (strong,nonatomic) GADInterstitial * interstitial;
+@property (weak, nonatomic) UIViewController *parentViewController;
+@property (weak, nonatomic) id<LARSAdControllerDelegate> adManager;
+@property (copy, nonatomic) NSString *publisherId;
+@property (nonatomic) BOOL adVisible;
+
+
+@end

--- a/Source/TOLAdAdapterGoogleAdsInterstitial.m
+++ b/Source/TOLAdAdapterGoogleAdsInterstitial.m
@@ -1,0 +1,77 @@
+//
+//  TOLAdApaterGoogleAdsInterstitial.m
+//  Pods
+//
+//  Created by Bruno Dal Bó Silva on 12/2/14.
+//
+//
+
+#import "TOLAdAdapterGoogleAdsInterstitial.h"
+
+@implementation TOLAdApaterGoogleAdsInterstitial
+
+
++ (BOOL)allowsBanner {
+    return NO;
+}
+
++ (BOOL)allowsInterstitial {
+    return YES;
+}
+
+- (void)dealloc {
+    self.adManager = nil;
+    self.publisherId = nil;
+    
+    self.interstitial = nil;
+    
+    TOLLog(@"Dealloc");
+}
+
+
+#pragma mark - Optional Adapter Implementation
+
+- (NSString *)friendlyNetworkDescription {
+    return @"Google Ads";
+}
+
+
+
+#pragma mark - Interstitial protocol implementation
+- (void)loadInterstitial {
+    self.interstitial = [[GADInterstitial alloc] init];
+    self.interstitial.adUnitID = self.publisherId ;
+    self.interstitial.delegate = self;
+    
+    GADRequest *request = [GADRequest request];
+    // Requests test ads on simulators.
+    request.testDevices = @[ GAD_SIMULATOR_ID ];
+    [self.interstitial loadRequest:request];
+}
+
+- (void)displayInterstitial {
+    if( _parentViewController != nil ) {
+        if( self.interstitial != nil ) {
+            if( self.interstitial.isReady ) {
+                [self.interstitial presentFromRootViewController:_parentViewController];
+                self.interstitial = nil; /* release it */
+            }
+        } else {
+            TOLWLog(@"Attempting to display unallocated interstitial");
+        }
+    } else {
+        TOLWLog(@"cannot display interstitial, controller does not have parent view");
+    }
+}
+
+#pragma mark - GADInterstitial delegate methos
+- (void)interstitialDidReceiveAd:(GADInterstitial *)ad {
+    TOLLog(@"got interstitial ad");
+}
+
+- (void)interstitial:(GADInterstitial *)ad didFailToReceiveAdWithError:(GADRequestError *)error {
+    TOLLog(@"failed to load interstitial ad");
+}
+
+
+@end

--- a/Source/TOLAdAdapteriAds.m
+++ b/Source/TOLAdAdapteriAds.m
@@ -34,6 +34,14 @@ NSString * const kTOLAdAdapterBannerLoadedObserverKeyPath = @"bannerLoaded";
 
 @implementation TOLAdAdapteriAds
 
++ (BOOL)allowsBanner {
+    return YES;
+}
+
++ (BOOL)allowsInterstitial {
+    return NO;
+}
+
 - (void)dealloc {
     [_bannerView removeObserver:self
                          forKeyPath:kTOLAdAdapterBannerLoadedObserverKeyPath];


### PR DESCRIPTION
this is a quick addition to allow full-screen ad banners. 
It's not yet fully functional but does add useful functionality for simple applications.
You have a way to call full-screen ads on the shared manager, the implementation tries to minimize friction with existing code.
Currently only admob adapter summons fullscreen ads, but it should be simple enough to add it to iAd adapter, I'll try to get around to it.
