### PR TITLE
Update constant to work with latest Google Ads SDK

### DIFF
--- a/Source/TOLAdAdapterGoogleAds.m
+++ b/Source/TOLAdAdapterGoogleAds.m
@@ -104,7 +104,7 @@
     GADRequest *request = [GADRequest request];
     
 #if TARGET_IPHONE_SIMULATOR
-    request.testDevices = [NSArray arrayWithObjects:GAD_SIMULATOR_ID, nil];
+    request.testDevices = [NSArray arrayWithObjects:kGADSimulatorID, nil];
 #endif
     
     [self.bannerView loadRequest:request];


### PR DESCRIPTION
When using the latest google admob SDK the GAD_Simulator constant returns an error.